### PR TITLE
CESR Parser

### DIFF
--- a/examples/integration-scripts/jest.setup.ts
+++ b/examples/integration-scripts/jest.setup.ts
@@ -1,1 +1,2 @@
+import 'jest-expect-message'; // allows expect() to have a custom message
 jest.setTimeout(30000);

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
     preset: 'ts-jest',
     testMatch: ['<rootDir>/test/**/*.test.ts'],
     projects: ['<rootDir>', '<rootDir>/examples/integration-scripts'],
+    setupFilesAfterEnv: ['jest-expect-message']
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^8.53.0",
         "eslint-config-prettier": "^9.0.0",
         "jest": "^29.3.1",
+        "jest-expect-message": "^1.1.3",
         "jest-fetch-mock": "^3.0.3",
         "jsdoc": "^4.0.2",
         "minami": "^1.2.3",
@@ -6806,6 +6807,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-expect-message": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-fetch-mock": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "jest": "^29.3.1",
+    "jest-expect-message": "^1.1.3",
     "jest-fetch-mock": "^3.0.3",
     "jsdoc": "^4.0.2",
     "minami": "^1.2.3",

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -3,7 +3,7 @@ import { b, d, Dict, Protocols, Ilks, Serials, versify } from '../core/core';
 import { Serder } from '../core/serder';
 import { nowUTC } from '../core/utils';
 import { Pather } from '../core/pather';
-import { Counter, CtrDex } from '../core/counter';
+import { Counter, CtrDex_1_0 } from '../core/counter';
 import { Saider } from '../core/saider';
 import { HabState } from '../core/keyState';
 
@@ -181,7 +181,7 @@ export function exchange(
         pathed += atc;
 
         const counter = new Counter({
-            code: CtrDex.PathedMaterialQuadlets,
+            code: CtrDex_1_0.PathedMaterialGroup,
             count: Math.floor(pathed.length / 4),
         });
         end += counter.qb64;

--- a/src/keri/core/core.ts
+++ b/src/keri/core/core.ts
@@ -225,6 +225,7 @@ export function deversify(
         const pa = proto as keyof typeof Protocols;
         proto = Protocols[pa];
 
+        // TODO change order of return to match the order of KERIpy: proto, vrsn, kind, size
         return [proto, kind, version, size];
     }
     throw new Error(`Invalid version string = ${versionString}`);
@@ -235,13 +236,13 @@ export function deversify(
  * protocol version, serialization type, and raw byte size of the serialization.
  *
  * Defaults to version 1.0.
- * @param ident
+ * @param proto
  * @param version
  * @param kind
  * @param size
  */
 export function versify(
-    ident: Protocols = Protocols.KERI,
+    proto: Protocols = Protocols.KERI,
     version?: Version,
     kind: Serials = Serials.JSON,
     size: number = 0
@@ -252,7 +253,7 @@ export function versify(
     // raw size in hex digits zero padded to 6 characters
     const rawSize = size.toString(16).padStart(6, '0');
     const terminationChar = '_'; // v1 termination character
-    return `${ident}${major}${minor}${kind}${rawSize}${terminationChar}`;
+    return `${proto}${major}${minor}${kind}${rawSize}${terminationChar}`;
 }
 
 /**

--- a/src/keri/core/counter.ts
+++ b/src/keri/core/counter.ts
@@ -11,25 +11,39 @@ export interface CounterArgs {
     strip?: boolean;
 }
 
-export class CounterCodex extends Codex {
+/**
+ * CounterCodex is codex hard (stable) part of all counter derivation codes.
+ * Only provide defined codes.
+ * Undefined are left out so that inclusion(exclusion) via 'in' operator works.
+ */
+export class CounterCodex_1_0 extends Codex {
     public ControllerIdxSigs: string = '-A'; // Qualified Base64 Indexed Signature.
     public WitnessIdxSigs: string = '-B'; // Qualified Base64 Indexed Signature.
     public NonTransReceiptCouples: string = '-C'; // Composed Base64 Couple, pre+cig.
     public TransReceiptQuadruples: string = '-D'; // Composed Base64 Quadruple, pre+snu+dig+sig.
     public FirstSeenReplayCouples: string = '-E'; // Composed Base64 Couple, fnu+dts.
     public TransIdxSigGroups: string = '-F'; // Composed Base64 Group, pre+snu+dig+ControllerIdxSigs group.
-    public SealSourceCouples: string = '-G'; // Composed Base64 couple, snu+dig of given delegators or issuers event
+    public SealSourceCouples: string = '-G'; // Composed Base64 couple, snu+dig of given delegator/issuer/transaction event
     public TransLastIdxSigGroups: string = '-H'; // Composed Base64 Group, pre+ControllerIdxSigs group.
     public SealSourceTriples: string = '-I'; // Composed Base64 triple, pre+snu+dig of anchoring source event
-    public SadPathSig: string = '-J'; // Composed Base64 Group path+TransIdxSigGroup of SAID of content
-    public SadPathSigGroup: string = '-K'; // Composed Base64 Group, root(path)+SaidPathCouples
-    public PathedMaterialQuadlets: string = '-L'; // Composed Grouped Pathed Material Quadlet (4 char each)
+    public SadPathSigGroup: string = '-J'; // Composed Base64 Group path+TransIdxSigGroup of SAID of content
+    public RootSadPathSigGroups: string = '-K'; // Composed Base64 Group, root(path)+SaidPathCouples
+    public PathedMaterialGroup: string = '-L'; // Composed Grouped Pathed Material Quadlet (4 char each)
+    public BigPathedMaterialGroup: string = '-0L'; // Composed Grouped Pathed Material Quadlet (4 char each)
     public AttachedMaterialQuadlets: string = '-V'; // Composed Grouped Attached Material Quadlet (4 char each)
     public BigAttachedMaterialQuadlets: string = '-0V'; // Composed Grouped Attached Material Quadlet (4 char each)
-    public KERIProtocolStack: string = '--AAA'; // KERI ACDC Protocol Stack CESR Version
+    public ESSRPayloadGroup: string = '-Z'; // ESSR Payload Group, dig of content+Texter group
+    public KERIACDCGenusVersion: string = '--AAA'; // KERI ACDC Protocol Stack CESR Version
 }
 
-export const CtrDex = new CounterCodex();
+/**
+ * Instantiation of version 1 of the CESR count code types allowing set membership checks with .has().
+ */
+export const CtrDex_1_0 = new CounterCodex_1_0();
+
+export class CounterCodex_2_0 extends Codex {
+    // TODO copy from KERIpy
+}
 
 export class Counter {
     static Sizes = new Map(

--- a/src/keri/core/eventing.ts
+++ b/src/keri/core/eventing.ts
@@ -98,14 +98,14 @@ export function rotate({
 
     let _nsith;
     if (nsith === undefined) {
-        _nsith = Math.max(1, Math.ceil(_ndigs.length / 2));
+        _nsith = Math.max(0, Math.ceil(_ndigs.length / 2));
     } else {
         _nsith = nsith;
     }
 
     const ntholder = new Tholder({ sith: _nsith });
-    if (ntholder.num != undefined && ntholder.num < 1) {
-        throw new Error(`Invalid sith = ${ntholder.num} less than 1.`);
+    if (ntholder.num != undefined && ntholder.num < 0) {
+        throw new Error(`Invalid sith = ${ntholder.num} less than 0.`);
     }
     if (ntholder.size > _ndigs.length) {
         // TODO this error should say that the threshold has not been met

--- a/src/keri/core/eventing.ts
+++ b/src/keri/core/eventing.ts
@@ -225,8 +225,8 @@ export function rotate({
             _toad && intive && _toad !== undefined && _toad <= MaxIntThold
                 ? _toad
                 : _toad.toString(16),
-        br: cuts,
-        ba: adds,
+        br: _cuts,
+        ba: _adds,
         a: data != undefined ? data : [],
     };
     const [, sad] = Saider.saidify(_sad);

--- a/src/keri/core/eventing.ts
+++ b/src/keri/core/eventing.ts
@@ -17,7 +17,7 @@ import { MtrDex, NonTransDex } from './matter';
 import { Saider } from './saider';
 import { Siger } from './siger';
 import { Cigar } from './cigar';
-import { Counter, CtrDex } from './counter';
+import { Counter, CtrDex_1_0 } from './counter';
 import { Seqner } from './seqner';
 
 const MaxIntThold = 2 ** 32 - 1;
@@ -432,7 +432,7 @@ export function messagize(
             if (seal[0] == 'SealEvent') {
                 atc = concat(
                     atc,
-                    new Counter({ code: CtrDex.TransIdxSigGroups, count: 1 })
+                    new Counter({ code: CtrDex_1_0.TransIdxSigGroups, count: 1 })
                         .qb64b
                 );
                 atc = concat(atc, new TextEncoder().encode(seal[1].i));
@@ -445,7 +445,7 @@ export function messagize(
                 atc = concat(
                     atc,
                     new Counter({
-                        code: CtrDex.TransLastIdxSigGroups,
+                        code: CtrDex_1_0.TransLastIdxSigGroups,
                         count: 1,
                     }).qb64b
                 );
@@ -456,7 +456,7 @@ export function messagize(
         atc = concat(
             atc,
             new Counter({
-                code: CtrDex.ControllerIdxSigs,
+                code: CtrDex_1_0.ControllerIdxSigs,
                 count: sigers.length,
             }).qb64b
         );
@@ -469,7 +469,7 @@ export function messagize(
         atc = concat(
             atc,
             new Counter({
-                code: CtrDex.ControllerIdxSigs,
+                code: CtrDex_1_0.ControllerIdxSigs,
                 count: wigers.length,
             }).qb64b
         );
@@ -488,7 +488,7 @@ export function messagize(
         atc = concat(
             atc,
             new Counter({
-                code: CtrDex.ControllerIdxSigs,
+                code: CtrDex_1_0.ControllerIdxSigs,
                 count: cigars.length,
             }).qb64b
         );
@@ -512,7 +512,7 @@ export function messagize(
         msg = concat(
             msg,
             new Counter({
-                code: CtrDex.AttachedMaterialQuadlets,
+                code: CtrDex_1_0.AttachedMaterialQuadlets,
                 count: Math.floor(atc.length / 4),
             }).qb64b
         );

--- a/src/keri/core/indexer.ts
+++ b/src/keri/core/indexer.ts
@@ -407,6 +407,26 @@ export class Indexer {
         return full;
     }
 
+    static sniffSize(ims: Buffer): number {
+        const first = String.fromCharCode(ims[0]);
+        if (!Array.from(Indexer.Hards.keys()).includes(first)) {
+            throw new Error(`Unexpected Indexer code ${first}`);
+        }
+
+        const hs = Indexer.Hards.get(first)!;
+        if (ims.length < hs) {
+            throw new Error(`Need ${hs - ims.length} more characters.`);
+        }
+
+        const hard = d(new Uint8Array(ims.subarray(0, hs)));
+        if (!Array.from(Indexer.Sizes.keys()).includes(hard)) {
+            throw new Error(`Unsupported code ${hard}`);
+        }
+
+        const xizage = Indexer.Sizes.get(hard)!;
+        return xizage.fs!;
+    }
+
     _exfil(qb64: string) {
         if (qb64.length == 0) {
             throw new Error('Empty Material');

--- a/src/keri/core/matter.ts
+++ b/src/keri/core/matter.ts
@@ -5,7 +5,14 @@ import { b, d } from './core';
 import { Buffer } from 'buffer';
 import { decodeBase64Url, encodeBase64Url } from './base64';
 
+/**
+ * Codex is a class that provides a mapping of property names to their corresponding values.
+ */
 export class Codex {
+    /**
+     * Returns true if the given property is a member of the codex.
+     * @param prop
+     */
     has(prop: string): boolean {
         const m = new Map(
             Array.from(Object.entries(this), (v) => [v[1], v[0]])

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -1,0 +1,1 @@
+export class Parser {}

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -252,7 +252,7 @@ export class CESRMessage {
 export class Parser {
     constructor() {}
 
-    *parse(
+    *msgParsator(
         ims: Buffer,
         framed = false,
         pipeline = false

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -1,1 +1,766 @@
-export class Parser {}
+import { Serder } from "./serder.ts";
+import { d, deversify } from "./core.ts";
+import { Siger } from "./siger.ts";
+import { Cigar } from "./cigar.ts";
+import { Counter, CtrDex } from "./counter.ts";
+import { Indexer } from "./indexer.ts";
+import { Matter } from "./matter.ts";
+import { Verfer } from "./verfer.ts";
+import { Prefixer } from "./prefixer.ts";
+import { Seqner } from "./seqner.ts";
+import { Saider } from "./saider.ts";
+import { Pather } from "./pather.ts";
+
+/**
+ * Cold start stream tritet codex.
+ *
+ * List of types (codex) of cold stream start tritets - the first three bits of the first byte of the stream.
+ * The values are in octal notation.
+ *
+ * Reference: ToIP CESR spec section 10.5.1 "Performant resynchronization with unique start bits"
+ * https://trustoverip.github.io/tswg-cesr-specification/#performant-resynchronization-with-unique-start-bits
+ *
+ * @type {{Free: number, CtB64: number, OpB64: number, JSON: number, MGPK1: number, CBOR: number, MGPK2: number, CtOpB2: number}}
+ */
+let ColdDex = {
+    /**
+     * Not taken, yet planned for annotated CESR
+     * Binary 000, full binary value 00000000
+     */
+    Free: 0o0,
+    /**
+     * CountCode Base64URLSafe starting character ('-') tritet, position 62 or 0x3E.
+     * Tritet bits 001, full binary 00101101, hex 0x2D
+     * Tritet is first three bits of the '-' character, ASCII/UTF-8 45.
+     */
+    CtB64: 0o1,
+    /**
+     * OpCode Base64URLSafe starting character ('_'), position 63 or 0x3F.
+     * Tritet bits 010, full binary 01011111, hex 0x5F
+     * Tritet is first three bits of the '_' character, ASCII/UTF-8 character 95.
+     */
+    OpB64: 0o2,
+    /**
+     * JSON Map starting character ('{') tritet.
+     * Tritet bits 011, full binary value 01111011, hex 0x7B
+     * Tritet is first three bits of the '{' character, ASCII/UTF-8 character 123.
+     */
+    JSON: 0o3,
+    /**
+     * MessagePack Fixed Map Event Start tritet
+     * Binary 100, full binary ?
+     */
+    MGPK1: 0o4,
+    /**
+     * CBOR Map Event Start
+     * Binary 101, full binary ?
+     */
+    CBOR: 0o5,
+    /**
+     * MessagePack Big 16 or 32 Map Event Start
+     * Binary 110, full binary ?
+     */
+    MGPK2: 0o6,
+    /**
+     * Base2 (binary) CountCode or OpCode starting character tritet
+     * Binary 111, full binary ?
+     */
+    CtOpB2: 0o7,
+}
+
+/**
+ * Stream cold start status
+ */
+export enum Cold {
+    msg = 'msg',
+    txt = 'txt',
+    bny = 'bny',
+}
+
+export enum BodyType {
+    S='S',
+    KERI= 'KERI',
+    ACDC= 'ACDC'
+}
+
+/**
+ * The main body of a CESR message that is either a KERI or ACDC event. Attachments come after.
+ */
+export class CESRBody {
+    private _bytes: Buffer; // raw bytes that will compose Serder
+    private _bodyType: BodyType; // Whether SerderKERI or SerderACDC; all Serder for now
+
+    constructor (bytes: Buffer, bodyType: BodyType = BodyType.S) {
+        this._bytes = bytes;
+        this._bodyType = bodyType;
+    }
+    get bodyType() {
+        return this._bodyType;
+    }
+    get bytes() {
+        return this._bytes;
+    }
+    get size() {
+        return this._bytes.length;
+    }
+}
+
+/**
+ * The various cryptographic primitives that can be included in a CESR message.
+ */
+export enum PrimType {
+    Bexter,
+    Cigar,
+    Cipher,
+    Counter,
+    Dater,
+    Decrypter,
+    Diger,
+    Encrypter,
+    Number,
+    Pather, // if the Pather is in a CESRAtcGroup and
+    PathedMaterialQuadlets,
+    Prefixer,
+    Saider,
+    Salter,
+    Seqner,
+    Signer,
+    Siger,
+    Verfer,
+}
+
+export class CESRPrim {
+    private _bytes: Buffer;
+    private _primitive: PrimType;
+    constructor(bytes: Buffer, primitive: PrimType) {
+        this._bytes = bytes;
+        this._primitive = primitive;
+    }
+    get bytes() {
+        return this._bytes;
+    }
+    get primitive() {
+        return this._primitive;
+    }
+}
+
+/**
+ * Union type for a CESR Tuple that allows single items, arrays of items, or a group.
+ */
+declare type CESRTupleType = (CESRPrim | CESRPrim[] | CESRTuple | CESRTuple[] | CESRAtcGroup)
+
+export class CESRTuple {
+    private _tuple: CESRTupleType[] = []
+    constructor(tuple: CESRTupleType[]) {
+        this._tuple = tuple;
+    }
+    get tuple() {
+        return this._tuple;
+    }
+}
+
+/**
+ * A single CESR attachment corresponding to one cryptographic primitive.
+ */
+export class CESRAtcGroup {
+    private _code: string; // derivation code
+    private _counter: CESRPrim;
+    private _path?: CESRPrim; // path for pathed groups
+    private _items: CESRPrim[] | CESRTuple[] = []; // list or tuple of cryptographic primitives
+    /**
+     *
+     * @param code
+     * @param items Primitives that are part of this group
+     * @param counter Count code for this group
+     * @param path Pather primitive for groups that have paths
+     */
+    constructor(
+      code: string,
+      items: CESRPrim[] | CESRTuple[],
+      counter: CESRPrim,
+      path?: CESRPrim
+    ) {
+        this._code = code;
+        this._counter = counter;
+        this._items = items;
+        this._path = path;
+    }
+    get code() {
+        return this._code;
+    }
+    get counter() {
+        return this._counter;
+    }
+    get items() {
+        return this._items;
+    }
+    get path() {
+        return this._path;
+    }
+}
+
+/**
+ * An ordered sequence of CESR attachments that comes after a CESRBody.
+ */
+export class CESRAttachments {
+    private _attachments: CESRAtcGroup[];
+    constructor(atcGroup: CESRAtcGroup[]) {
+        this._attachments = atcGroup;
+    }
+    get attachments() {
+        return this._attachments;
+    }
+    add(atcGroup: CESRAtcGroup) {
+        this._attachments.push(atcGroup);
+    }
+}
+
+/**
+ * A complete CESR message that includes a body and attachments.
+ */
+export class CESRMessage {
+    private _body: CESRBody;
+    private _attachments: CESRAttachments;
+
+    constructor(body: CESRBody, attachments: CESRAttachments) {
+        this._body = body;
+        this._attachments = attachments;
+    }
+
+    get body() {
+        return this._body;
+    }
+
+    get atc() {
+        return this._attachments;
+    }
+}
+
+/**
+ * CESR stream primitive parser. Turns a stream of bytes into a collection of CESRMessage objects.
+ * These objects can then be converted into cryptographic primitives with Hydrator.
+ */
+export class Parser {
+    constructor() {}
+
+    *parse(
+        ims: Buffer,
+        framed = false,
+        pipeline = false
+    ): Generator<CESRMessage | null, void, unknown> {
+        if (ims.length === 0) return;
+        let cold = this.sniff(ims);
+        if ([Cold.txt, Cold.bny].includes(cold)) {
+            throw new Error(`Cold start error: expecting message counter tritet, got ${cold}`)
+        }
+        while (true) {
+            if (ims.length === 0) return;
+            const body = this.reap(ims);
+            ims = ims.subarray(body.size);
+            const sigers: Siger[] = []; // attached indexed controller signatures
+            const wigers: Siger[] = []; // attached indexed witness signatures
+            const cigars: Cigar[] = []; // non-transferable receipt couples
+            const trqs: any = []; // transferable receipt (vrc) quadruples - (prefixer, seqner, diger, siger)
+            const tsgs: any = []; // transferable indexed sig groups - (i, s, d) plus list of sigs
+            const ssgs: any = []; // signer seal sig groups - identifier prefix plus list of sigs
+            const frcs: any = []; // first seen replay couples - (seqner, dater)
+            const sscs: any = []; // source seal couples (delegator or issuer) - (seqner, diger) for delegating or issuing event
+            const ssts: any = []; // source seal triples (issuer or issuance TEL evt) - (seqner, diger) for delegating or issuing event
+            const sadtsgs: any = []; // SAD path sig groups from transferable identifiers - (path, i, s, d) plus list of sigs
+            const sadcigs: any = []; // SAD path sig groups from non-transferable identifiers - path plus list of non-trans sigs
+            const pathed: any = []; // grouped attachments targetting a subpath
+            let pipelined: boolean = false;
+
+            cold = this.sniff(ims);
+            if (cold === Cold.msg) {
+                throw new Error(`Cold start error: expecting attachment or binary counter tritet, got ${cold}`)
+            }
+            // TODO support qb2 for binary attachments - rig ht now only qb64b
+            let ctr: Counter;
+            if (cold === Cold.txt) ctr = new Counter({qb64b: ims});
+            else if (cold === Cold.bny) ctr = new Counter({qb2: ims});
+            else throw new Error(`Attachment cold start error: expecting text or binary counter, got ${cold}`)
+            ims = ims.subarray(Counter.Sizes.get(ctr.code)!.fs!);
+
+            // strip off initial attachment count code
+            if (ctr.code === CtrDex.AttachedMaterialQuadlets) { // pipeline ctr?
+                pipelined = true
+                // compute pipelined attached group size (pags) based on txt or bny
+                const pags = cold === Cold.txt ? ctr.count * 4 : ctr.count * 3
+                if (ims.length < pags) throw new Error(`Insufficient bytes to parse pipelined attachments.`)
+
+                // pipelined attachments
+                const pims = ims.subarray(0, pags)
+                ims = ims.subarray(pags);
+                if (pipelined) {
+                    // TODO parse pipelined attachments
+                    return
+                }
+                ctr = new Counter({qb64b: ims});
+            }
+
+            // process attachments
+            const attachments = new CESRAttachments([]);
+            let group: CESRAtcGroup;
+            let groups: CESRAtcGroup[];
+            switch (ctr.code) {
+                case CtrDex.ControllerIdxSigs:
+                    [ims, group] = AtcParser.ControllerIdxSigs(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.WitnessIdxSigs:
+                    [ims, group] = AtcParser.WitnessIdxSigs(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.NonTransReceiptCouples:
+                    [ims, group] = AtcParser.NonTransReceiptCouples(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.TransReceiptQuadruples:
+                    [ims, group] = AtcParser.TransReceiptQuadruples(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.TransIdxSigGroups:
+                    [ims, group] = AtcParser.TransIdxSigGroups(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.TransLastIdxSigGroups:
+                    [ims, group] = AtcParser.TransLastIdxSigGroups(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.FirstSeenReplayCouples:
+                    [ims, group] = AtcParser.FirstSeenReplayCouples(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.SealSourceCouples:
+                    [ims, group] = AtcParser.SealSourceCouples(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.SealSourceTriples:
+                    [ims, group] = AtcParser.SealSourceTriples(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.SadPathSigGroup:
+                    [ims, group] = AtcParser.SadPathSigGroup(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.SadPathSig:
+                    [ims, group] = AtcParser.SadPathSig(ims, ctr);
+                    attachments.add(group);
+                    break;
+                case CtrDex.PathedMaterialQuadlets:
+                    [ims, group] = AtcParser.PathedMaterialQuadlets(ims, ctr, cold);
+                    attachments.add(group);
+                    break;
+                default:
+                    throw new Error(`Unknown attachment counter code ${ctr.code}`)
+            }
+
+            yield new CESRMessage(body, attachments);
+        }
+    }
+
+    sniff(ims: Buffer): Cold {
+        if (ims.length === 0) throw new Error('Empty stream');
+        const tritet = ims[0] >> 5;
+        if ([ColdDex.JSON, ColdDex. MGPK1, ColdDex.CBOR, ColdDex.MGPK2].includes(tritet)) {
+            return Cold.msg;
+        }
+        if ([ColdDex.CtB64, ColdDex.OpB64].includes(tritet)) {
+            return Cold.txt;
+        }
+        if ([ColdDex.CtOpB2].includes(tritet)) {
+            return Cold.bny;
+        }
+        throw new Error(`Unknown cold start tritet ${tritet}`);
+    }
+
+    reap(ims: Buffer): CESRBody {
+        if (ims.length < Serder.InhaleSize) {
+            throw new Error(`Insufficient bytes to parse message.`);
+        }
+        const [proto, kind, version, size] = deversify(d(ims.subarray(0, Serder.InhaleSize)));
+        // TODO add CESR 2 version string compatibility
+        let sizeNum = parseInt(size, 16); // assumes CESR v1 so size is hex str
+        return new CESRBody(ims.subarray(0, sizeNum));
+    }
+
+}
+
+/**
+ * Parses the various types of attachments that can be included with a CESR message.
+ * All functions take the incoming stream and strip the existing attachment from the returned stream.
+ */
+class AtcParser {
+    static ControllerIdxSigs(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const items: CESRPrim[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            const size = Indexer.sniffSize(ims);
+            // extract the controller signature
+            const siger = new CESRPrim(ims.subarray(0, size), PrimType.Siger)
+            ims = ims.subarray(size);
+
+            items.push(siger);
+        }
+        const group = new CESRAtcGroup(ctr.code, items,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group];
+    }
+
+    static WitnessIdxSigs(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const items: CESRPrim[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            const size = Indexer.sniffSize(ims);
+            // extract the witness signature
+            const siger = new CESRPrim(ims.subarray(0, size), PrimType.Siger)
+            ims = ims.subarray(size);
+
+            items.push(siger);
+        }
+        const group =new CESRAtcGroup(ctr.code, items,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group];
+    }
+
+    static NonTransReceiptCouples(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const tuples: CESRTuple[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            // extract the couple (verfer, cigar)
+            let size = Matter.sniffSize(ims);
+            const verfer = new CESRPrim(ims.subarray(0, size), PrimType.Verfer)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const cigar = new CESRPrim(ims.subarray(0, size), PrimType.Cigar)
+            ims = ims.subarray(size);
+
+            tuples.push(new CESRTuple([verfer, cigar]));
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group];
+    }
+
+    /**
+     * Extract attached trans receipt vrc quadruple
+     * spre+ssnu+sdig+sig
+     * @param ims
+     * @param ctr
+     * @constructor
+     */
+    static TransReceiptQuadruples(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const tuples: CESRTuple[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            let size = Matter.sniffSize(ims);
+            const prefixer = new CESRPrim(ims.subarray(0, size), PrimType.Prefixer)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const seqner = new CESRPrim(ims.subarray(0, size), PrimType.Seqner)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const saider = new CESRPrim(ims.subarray(0, size), PrimType.Saider)
+            ims = ims.subarray(size);
+
+            size = Indexer.sniffSize(ims);
+            const siger = new CESRPrim(ims.subarray(0, size), PrimType.Siger)
+            ims = ims.subarray(size);
+
+            tuples.push(new CESRTuple([prefixer, seqner, saider, siger]));
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+            new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group];
+    }
+
+    /**
+     * Extract attaced trans indexed sig groups each made of
+     * triple pre+snu+dig plus indexed sig group
+     * pre is pre of signer (endorser) of msg
+     * snu is sn of signer's est evt when signed
+     * dig is dig of signer's est event when signed
+     * followed by counter for ControllerIdxSigs with attached
+     * indexed sigs from trans signer (endorser).
+     * @param ims
+     * @param ctr
+     * @constructor
+     */
+    static TransIdxSigGroups(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const tuples: CESRTuple[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            let size = Matter.sniffSize(ims);
+            const prefixer = new CESRPrim(ims.subarray(0, size), PrimType.Prefixer)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const seqner = new CESRPrim(ims.subarray(0, size), PrimType.Seqner)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const saider = new CESRPrim(ims.subarray(0, size), PrimType.Saider)
+            ims = ims.subarray(size);
+
+            const sigers: CESRPrim[] = [];
+            const sigCtr = new Counter({qb64b: ims});
+            if (sigCtr.code !== CtrDex.ControllerIdxSigs) throw new Error(`Invalid group code. Expected ControllerIdxSigs (${CtrDex.ControllerIdxSigs}) got ${sigCtr.code}`);
+            ims = ims.subarray(Counter.Sizes.get(sigCtr.code)!.fs!);
+            for (let j = 0; j < sigCtr.count; j++) {
+                size = Indexer.sniffSize(ims);
+                const siger = new CESRPrim(ims.subarray(0, size), PrimType.Siger)
+                sigers.push(siger);
+                ims = ims.subarray(size);
+            }
+            // child group
+            const sigGroup = new CESRAtcGroup(
+                sigCtr.code,
+                sigers,
+                new CESRPrim(Buffer.from(sigCtr.qb64b), PrimType.Counter)
+            );
+            tuples.push(new CESRTuple([prefixer, seqner, saider, sigGroup]));
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+            new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group];
+    }
+
+    /**
+     * Extract attached signer seal indexed sig groups each made of
+     * identifier pre plus indexed sig group
+     * pre is pre of signer (endorser) of msg
+     * followed by counter for ControllerIdxSigs with attached
+     * indexed sigs from trans signer (endorser).
+     * @param ims
+     * @param ctr
+     * @constructor
+     */
+    static TransLastIdxSigGroups(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const tuples: CESRTuple[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            let size = Matter.sniffSize(ims);
+            const prefixer = new CESRPrim(ims.subarray(0, size), PrimType.Prefixer)
+            ims = ims.subarray(size);
+
+            const sigers: CESRPrim[] = [];
+            const sigCtr = new Counter({qb64b: ims});
+            if (sigCtr.code !== CtrDex.ControllerIdxSigs) throw new Error(`Invalid group code. Expected ControllerIdxSigs (${CtrDex.ControllerIdxSigs}) got ${sigCtr.code}`);
+            ims = ims.subarray(Counter.Sizes.get(sigCtr.code)!.fs!);
+            for (let j = 0; j < sigCtr.count; j++) {
+                size = Indexer.sniffSize(ims);
+                const siger = new CESRPrim(ims.subarray(0, size), PrimType.Siger)
+                sigers.push(siger);
+                ims = ims.subarray(size);
+            }
+            const sigGroup = new CESRAtcGroup(sigCtr.code, sigers,
+                new CESRPrim(Buffer.from(sigCtr.qb64b), PrimType.Counter)
+            );
+            tuples.push(new CESRTuple([prefixer, sigGroup]));
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter))
+        return [ims, group]
+    }
+
+    /**
+     * Extract attached first seen replay couples
+     * snu+dtm
+     * snu is fn (first seen ordinal) of event
+     * dtm is dt of event
+     * @param ims
+     * @param ctr
+     * @constructor
+     */
+    static FirstSeenReplayCouples(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const tuples: CESRTuple[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            let size = Matter.sniffSize(ims);
+            const seqner = new CESRPrim(ims.subarray(0, size), PrimType.Seqner)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const dater = new CESRPrim(ims.subarray(0, size), PrimType.Dater)
+            ims = ims.subarray(size);
+
+            tuples.push(new CESRTuple([seqner, dater]));
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+            new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group]
+    }
+
+    /**
+     * Extract attached first seen replay couples
+     * snu+dig
+     * snu is sequence number  of event
+     * dig is digest of event
+     * @param ims
+     * @param ctr
+     * @constructor
+     */
+    static SealSourceCouples(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const tuples: CESRTuple[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            let size = Matter.sniffSize(ims);
+            const seqner = new CESRPrim(ims.subarray(0, size), PrimType.Seqner)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const saider = new CESRPrim(ims.subarray(0, size), PrimType.Saider)
+            ims = ims.subarray(size);
+
+            tuples.push(new CESRTuple([seqner, saider]));
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group]
+    }
+
+    /**
+     * Extract attached anchoring source event information
+     * pre+snu+dig
+     * pre is prefix of event
+     * snu is sequence number  of event
+     * dig is digest of event
+     * @param ims
+     * @param ctr
+     * @constructor
+     */
+    static SealSourceTriples(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        const tuples: CESRTuple[] = [];
+        for (let i = 0; i < ctr.count; i++) {
+            let size = Matter.sniffSize(ims);
+            const prefixer = new CESRPrim(ims.subarray(0, size), PrimType.Prefixer)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const seqner = new CESRPrim(ims.subarray(0, size), PrimType.Seqner)
+            ims = ims.subarray(size);
+
+            size = Matter.sniffSize(ims);
+            const saider = new CESRPrim(ims.subarray(0, size), PrimType.Saider)
+            ims = ims.subarray(size);
+
+            tuples.push(
+                new CESRTuple([prefixer, seqner, saider])
+            );
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group]
+    }
+
+    /**
+     * Extract attached SAD path sig groups each made of a top level Pather, a counter for SadPathSig groups,
+     * and then within each sad path group a Pather and another count code which may count groups of either
+     * TransIdxSigGroups, ControllerIdxSigs, or NonTransReceiptCouples.
+     * @param ims
+     * @param ctr count of SAD path sig groups
+     * @constructor
+     */
+    static SadPathSigGroup(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        let tuples: CESRTuple[] = [];
+        // get Pather
+        const size = Matter.sniffSize(ims);
+        const rootPath = new CESRPrim(ims.subarray(0, size), PrimType.Pather);
+        ims = ims.subarray(size);
+
+        // get nested groups
+        for (let i = 0; i < ctr.count; i++) {
+            // get Counter of subgroups of a specific type
+            const sigGroupCtr = new Counter({qb64b: ims});
+            ims = ims.subarray(Counter.Sizes.get(sigGroupCtr.code)!.fs!);
+
+            [ims, tuples] = AtcParser._sadPathSigGroup(ims, sigGroupCtr);
+        }
+        const group = new CESRAtcGroup(ctr.code, tuples,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter),
+          rootPath);
+        return [ims, group]
+    }
+
+    /**
+     * Extract SAD path sig groups
+     * @param ims incoming message stream
+     * @param ctr count of subgroups within this sig group
+     */
+    static _sadPathSigGroup(ims: Buffer, ctr: Counter): [Buffer, CESRTuple[]] {
+      if (ctr.code !== CtrDex.SadPathSig)
+          throw new Error(`Expected SadPathSig counter, got ${ctr.code}`);
+
+      // get subpath
+      const size = Matter.sniffSize(ims);
+      const subpath = new CESRPrim(ims.subarray(0, size), PrimType.Pather);
+      ims = ims.subarray(size);
+
+      // get sig group counter
+      const sctr = new Counter({qb64b: ims});
+      ims = ims.subarray(Counter.Sizes.get(sctr.code)!.fs!);
+
+      // pull items from each group and return an array of tuples
+      let group: CESRAtcGroup;
+      const tuples: CESRTuple[] = [];
+      let tuple: CESRTuple;
+      switch (sctr.code) {
+          case CtrDex.TransIdxSigGroups:
+              [ims, group] = AtcParser.TransIdxSigGroups(ims, sctr);
+              // TODO add each inner group to the outer group, maybe return a CESRGroup
+              group.items.forEach((gTuple) => {
+                  // todo do type check of gTuple to ensure it is a CESRTuple
+                  // tuple = sctr.code, (subpath, prefixer, seqner, saider, isigers)
+                  tuple = new CESRTuple([
+                    new CESRPrim(Buffer.from(sctr.qb64b), PrimType.Counter),
+                    new CESRTuple([subpath, ...((gTuple as CESRTuple).tuple)])
+                  ]);
+                  tuples.push(tuple)
+              });
+              break;
+          case CtrDex.ControllerIdxSigs:
+              [ims, group] = AtcParser.ControllerIdxSigs(ims, sctr);
+              // tuple = sctr.code, (subpath, isigers)
+              tuple = new CESRTuple([
+                  new CESRPrim(Buffer.from(sctr.qb64b), PrimType.Counter),
+                  new CESRTuple([subpath, group.items])
+              ])
+              tuples.push(tuple)
+              break;
+          case CtrDex.NonTransReceiptCouples:
+              [ims, group] = AtcParser.NonTransReceiptCouples(ims, sctr);
+              group.items.forEach((gTuple) => {
+                // tuple = sctr.code, (subpath, cigar)
+                // in this case it is sctr.code, (subpath, verfer, cigar) because the two are not yet combined
+                // TODO note for parsing: remember to combine the verfer to cigar.verfer
+                tuple = new CESRTuple([
+                    new CESRPrim(Buffer.from(sctr.qb64b), PrimType.Counter),
+                    new CESRTuple([subpath, ...((gTuple as CESRTuple).tuple)])
+                ])
+                tuples.push(tuple);
+              });
+              break;
+          default:
+              throw new Error(`Wrong count code = ${sctr.code} in SAD path sig group`)
+      }
+      return [ims, tuples];
+    }
+
+    static SadPathSig(ims: Buffer, ctr: Counter): [Buffer, CESRAtcGroup] {
+        let tuples: CESRTuple[] = [];
+        [ims, tuples] = AtcParser._sadPathSigGroup(ims, ctr);
+        const group = new CESRAtcGroup(ctr.code, tuples,
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group];
+    }
+
+    static PathedMaterialQuadlets(ims: Buffer, ctr: Counter, cold: Cold): [Buffer, CESRAtcGroup] {
+        // compute pipelined attached group size based on txt or bny
+        const pags = cold === Cold.txt ? ctr.count  * 4 : ctr.count * 3;
+        if (ims.length < pags)
+            throw new Error(`Not enough bytes to parse pathed material quadlets. Got ${ims.length} need ${pags}`);
+        const pims = ims.subarray(0, pags);
+        ims = ims.subarray(pags);
+        const prim = new CESRPrim(pims, PrimType.PathedMaterialQuadlets)
+
+        const group = new CESRAtcGroup(ctr.code, [prim],
+          new CESRPrim(Buffer.from(ctr.qb64b), PrimType.Counter));
+        return [ims, group];
+    }
+}

--- a/src/keri/core/prefixer.ts
+++ b/src/keri/core/prefixer.ts
@@ -131,7 +131,7 @@ export class Prefixer extends Matter {
             throw new Error(`Error extracting public key = ${e}`);
         }
 
-        if (verfer.code in [MtrDex.Ed25519]) {
+        if ([MtrDex.Ed25519].includes(verfer.code)) {
             throw new Error(`Mismatch derivation code = ${verfer.code}`);
         }
 

--- a/src/keri/core/salter.ts
+++ b/src/keri/core/salter.ts
@@ -158,6 +158,20 @@ export class Salter extends Matter {
         });
     }
 
+    signers(
+      count = 1,
+      path = "",
+      code = MtrDex.Ed25519_Seed,
+      transferable = true,
+      start = 0,
+      tier = Tier.low,
+      temp = false): Signer[] {
+        return [...Array(count).keys()].map((i) => {
+            const indexedPath=`${path}${(i + start).toString(16)}`
+          return this.signer(code, transferable, indexedPath, tier, temp)
+        })
+    }
+
     get tier(): Tier | null {
         return this._tier;
     }

--- a/src/keri/core/serder.ts
+++ b/src/keri/core/serder.ts
@@ -12,7 +12,7 @@ import {
 import { Verfer } from './verfer';
 import { Diger } from './diger';
 import { CesrNumber } from './number';
-import { Tholder } from "./tholder.ts";
+import { Tholder } from "./tholder";
 
 export class Serder {
     protected _kind: Serials;

--- a/src/keri/core/serder.ts
+++ b/src/keri/core/serder.ts
@@ -1,25 +1,27 @@
 import { MtrDex } from './matter';
 import {
+    b,
     deversify,
-    Dict,
+    Dict, Ilks, MINSNIFFSIZE,
     Protocols,
     Serials,
     versify,
     Version,
-    Vrsn_1_0,
-} from './core';
+    Vrsn_1_0
+} from "./core";
 import { Verfer } from './verfer';
 import { Diger } from './diger';
 import { CesrNumber } from './number';
+import { Tholder } from "./tholder.ts";
 
 export class Serder {
-    private _kind: Serials;
-    private _raw: string = '';
-    private _sad: Dict<any> = {};
-    private _proto: Protocols = Protocols.KERI;
-    private _size: number = 0;
-    private _version: Version = Vrsn_1_0;
-    private readonly _code: string;
+    protected _kind: Serials;
+    protected _raw: string = '';
+    protected _sad: Dict<any> = {};
+    protected _proto: Protocols = Protocols.KERI;
+    protected _size: number = 0;
+    protected _version: Version = Vrsn_1_0;
+    protected readonly _code: string;
 
     /**
      * Creates a new Serder object from a self-addressing data dictionary.
@@ -32,7 +34,7 @@ export class Serder {
         kind: Serials = Serials.JSON,
         code: string = MtrDex.Blake3_256
     ) {
-        let [raw, proto, eKind, eSad, version] = this._exhale(sad, kind);
+        const [raw, proto, eKind, eSad, version] = this._exhale(sad, kind);
         this._raw = raw;
         this._sad = eSad;
         this._proto = proto;
@@ -42,6 +44,9 @@ export class Serder {
         this._size = raw.length;
     }
 
+    /**
+     * Self-addressing / serializable data dictionary property getter.
+     */
     get sad(): Dict<any> {
         return this._sad;
     }
@@ -136,6 +141,120 @@ export class Serder {
     pretty() {
         return JSON.stringify(this._sad, undefined, 2);
     }
+
+    static InhaleSize = MINSNIFFSIZE;
+}
+
+/**
+ * An individual key event log (KEL) message.
+ * Provides Serialization and deserialization for key event messages and properties
+ * for exposing field values of KERI messages.
+ *
+ * See docs for {@link Serder}.
+ */
+export class SerderKERI extends Serder {
+
+    constructor(
+        sad: Dict<any>,
+        kind: Serials = Serials.JSON,
+        code: string = MtrDex.Blake3_256
+    ) {
+        super(sad, kind, code);
+        this._proto = Protocols.KERI;
+    }
+
+    /**
+     * Verifies SAID(s) in SAD against raw.
+     * @param sad
+     */
+    verify(sad: Dict<any>) {
+        throw new Error('Method not implemented.');
+    }
+
+    /**
+     * Returns whether the event is an establishment event.
+     */
+    get estive() {
+        return "t" in this.sad &&
+            [Ilks.icp, Ilks.rot, Ilks.dip, Ilks.drt].includes(this.sad["t"])
+    }
+
+    /**
+     * Key event dict property getter. Alias for .sad
+     */
+    get ked() {
+        return this.sad
+    }
+
+    /**
+     * Identifier prefix property getter.
+     */
+    get pre() {
+        return this.sad['i'];
+    }
+
+    /**
+     * Identifier prefix property getter as bytes.
+     */
+    get preb() {
+        return b(this.pre);
+    }
+
+    /**
+     * Sequence number property getter as CesrNumber.
+     */
+    get sner() {
+        return new CesrNumber({}, this.sad['s']);
+    }
+
+    /**
+     * Sequence number property getter as number.
+     */
+    get sn() {
+        return this.sner.num;
+    }
+
+    /**
+     * Sequence number property getter as hex string.
+     */
+    get snh() {
+        return this.sner.numh;
+    }
+
+    /**
+     * Seals attribute data property getter
+     */
+    get seals() {
+        return this.sad['a'];
+    }
+
+    /**
+     * Traits list property getter (config traits)
+     */
+    get traits() {
+        return this.sad['c'];
+    }
+
+    /**
+     * Threshold holder property getter
+     */
+    get tholder() {
+        return new Tholder({sith: this.sad['kt']})
+    }
+
+    /**
+     * Returns list of current signing keys in fully qualified Base64.
+     */
+    get keys() {
+        return this.sad['k'];
+    }
+
+    get uuid() {
+        return this.sad['u'];
+    }
+
+
+
 }
 
 export function dumps(sad: Object, kind: Serials.JSON): string {

--- a/src/keri/core/utils.ts
+++ b/src/keri/core/utils.ts
@@ -1,4 +1,4 @@
-import { Counter, CtrDex } from './counter';
+import { Counter, CtrDex_1_0 } from './counter';
 import { Seqner } from './seqner';
 import { Prefixer } from './prefixer';
 import { Saider } from './saider';
@@ -120,7 +120,7 @@ export function serializeACDCAttachment(anc: Serder): Uint8Array {
     const seqner = new Seqner({ sn: anc.sn });
     const saider = new Saider({ qb64: anc.sad['d'] });
     const craw = new Uint8Array();
-    const ctr = new Counter({ code: CtrDex.SealSourceTriples, count: 1 }).qb64b;
+    const ctr = new Counter({ code: CtrDex_1_0.SealSourceTriples, count: 1 }).qb64b;
     const prefix = prefixer.qb64b;
     const seq = seqner.qb64b;
     const said = saider.qb64b;
@@ -144,7 +144,7 @@ export function serializeIssExnAttachment(anc: Serder): Uint8Array {
     coupleArray.set(seqner.qb64b);
     coupleArray.set(ancSaider.qb64b, seqner.qb64b.length);
     const counter = new Counter({
-        code: CtrDex.SealSourceCouples,
+        code: CtrDex_1_0.SealSourceCouples,
         count: 1,
     });
     const counterQb64b = counter.qb64b;
@@ -158,7 +158,7 @@ export function serializeIssExnAttachment(anc: Serder): Uint8Array {
         );
     }
     const pcnt = new Counter({
-        code: CtrDex.AttachedMaterialQuadlets,
+        code: CtrDex_1_0.AttachedMaterialQuadlets,
         count: Math.floor(atc.length / 4),
     });
     const msg = new Uint8Array(pcnt.qb64b.length + atc.length);

--- a/test/core/counter.test.ts
+++ b/test/core/counter.test.ts
@@ -1,4 +1,4 @@
-import { Counter, CtrDex } from '../../src/keri/core/counter';
+import { Counter, CtrDex_1_0 } from '../../src/keri/core/counter';
 import { strict as assert } from 'assert';
 import { b, b64ToInt, intToB64 } from '../../src/keri/core/core';
 
@@ -37,24 +37,24 @@ describe('int to b64 and back', () => {
         });
 
         let count = 1;
-        let qsc = CtrDex.ControllerIdxSigs + intToB64(count, 2);
+        let qsc = CtrDex_1_0.ControllerIdxSigs + intToB64(count, 2);
         assert.equal(qsc, '-AAB');
         let qscb = b(qsc);
 
-        let counter = new Counter({ code: CtrDex.ControllerIdxSigs }); // default count = 1
-        assert.equal(counter.code, CtrDex.ControllerIdxSigs);
+        let counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs }); // default count = 1
+        assert.equal(counter.code, CtrDex_1_0.ControllerIdxSigs);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
 
         counter = new Counter({ qb64: qsc }); // default count = 1
-        assert.equal(counter.code, CtrDex.ControllerIdxSigs);
+        assert.equal(counter.code, CtrDex_1_0.ControllerIdxSigs);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
 
         counter = new Counter({ qb64b: qscb }); // default count = 1
-        assert.equal(counter.code, CtrDex.ControllerIdxSigs);
+        assert.equal(counter.code, CtrDex_1_0.ControllerIdxSigs);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
@@ -69,51 +69,51 @@ describe('int to b64 and back', () => {
         });
 
         count = 5;
-        qsc = CtrDex.ControllerIdxSigs + intToB64(count, 2);
+        qsc = CtrDex_1_0.ControllerIdxSigs + intToB64(count, 2);
         assert.equal(qsc, '-AAF');
         qscb = b(qsc);
 
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs, count: count });
-        assert.equal(counter.code, CtrDex.ControllerIdxSigs);
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs, count: count });
+        assert.equal(counter.code, CtrDex_1_0.ControllerIdxSigs);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
 
         counter = new Counter({ qb64: qsc }); // default count = 1
-        assert.equal(counter.code, CtrDex.ControllerIdxSigs);
+        assert.equal(counter.code, CtrDex_1_0.ControllerIdxSigs);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
 
         counter = new Counter({ qb64b: qscb }); // default count = 1
-        assert.equal(counter.code, CtrDex.ControllerIdxSigs);
+        assert.equal(counter.code, CtrDex_1_0.ControllerIdxSigs);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
 
         // test with big codes index=1024
         count = 1024;
-        qsc = CtrDex.BigAttachedMaterialQuadlets + intToB64(count, 5);
+        qsc = CtrDex_1_0.BigAttachedMaterialQuadlets + intToB64(count, 5);
         assert.equal(qsc, '-0VAAAQA');
         qscb = b(qsc);
 
         counter = new Counter({
-            code: CtrDex.BigAttachedMaterialQuadlets,
+            code: CtrDex_1_0.BigAttachedMaterialQuadlets,
             count: count,
         });
-        assert.equal(counter.code, CtrDex.BigAttachedMaterialQuadlets);
+        assert.equal(counter.code, CtrDex_1_0.BigAttachedMaterialQuadlets);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
 
         counter = new Counter({ qb64: qsc }); // default count = 1
-        assert.equal(counter.code, CtrDex.BigAttachedMaterialQuadlets);
+        assert.equal(counter.code, CtrDex_1_0.BigAttachedMaterialQuadlets);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
 
         counter = new Counter({ qb64b: qscb }); // default count = 1
-        assert.equal(counter.code, CtrDex.BigAttachedMaterialQuadlets);
+        assert.equal(counter.code, CtrDex_1_0.BigAttachedMaterialQuadlets);
         assert.equal(counter.count, count);
         assert.deepStrictEqual(counter.qb64b, qscb);
         assert.equal(counter.qb64, qsc);
@@ -122,15 +122,15 @@ describe('int to b64 and back', () => {
         const version = intToB64(verint, 3);
         assert.equal(version, 'AAA');
         assert.equal(verint, b64ToInt(version));
-        qsc = CtrDex.KERIProtocolStack + version;
+        qsc = CtrDex_1_0.KERIACDCGenusVersion + version;
         assert.equal(qsc, '--AAAAAA'); // keri Cesr version 0.0.0
         qscb = b(qsc);
 
         counter = new Counter({
-            code: CtrDex.KERIProtocolStack,
+            code: CtrDex_1_0.KERIACDCGenusVersion,
             count: verint,
         });
-        assert.equal(counter.code, CtrDex.KERIProtocolStack);
+        assert.equal(counter.code, CtrDex_1_0.KERIACDCGenusVersion);
         assert.equal(counter.count, verint);
         assert.equal(counter.countToB64(3), version);
         assert.equal(counter.countToB64(), version); // default length

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -1,6 +1,20 @@
 // write a test in jest of the Parser class
 import { Parser } from '../../src/keri/core/parsing';
-import signify, { b, d, Diger, incept, MtrDex, Salter, Tier } from "../../src";
+import signify, {
+    b,
+    Counter,
+    CtrDex,
+    d,
+    Diger,
+    incept,
+    interact,
+    MtrDex,
+    rotate,
+    Salter,
+    Serials,
+    Tier,
+    Vrsn_1_0,
+} from '../../src';
 
 describe('Parser', () => {
     let parser: Parser;
@@ -10,21 +24,254 @@ describe('Parser', () => {
     });
 
     it('should create a new Parser instance', async () => {
+        expect(parser).toBeInstanceOf(Parser);
         await signify.ready();
         const raw = b('ABCDEFGH01234567');
-        const signers = new Salter({ raw }).signers(8, 'psr', MtrDex.Ed25519_Seed, true, 0, Tier.low, true);
+        const signers = new Salter({ raw }).signers(
+            8,
+            'psr',
+            MtrDex.Ed25519_Seed,
+            true,
+            0,
+            Tier.low,
+            true
+        );
+        let signKey = signers[0]; // first key is used for inception as signing key
+        let nextKey = signers[1]; // second key is used to specify the next key digest
 
-        const signKey1qb64 = signers[0].verfer.qb64;
-        const rotKey1qb64b = signers[1].verfer.qb64b;
-        const rotKey1Digest = new Diger({code: MtrDex.Blake3_256}, rotKey1qb64b).qb64
-        expect(signers[0].verfer.qb64).toEqual(signKey1qb64)
+        const icp0KeyQb64 = signKey.verfer.qb64;
+        const rot1KeyQb64b = nextKey.verfer.qb64b;
+        const rot1KeyDigest = new Diger(
+            { code: MtrDex.Blake3_256 },
+            rot1KeyQb64b
+        ).qb64;
+        expect(signKey.verfer.qb64).toEqual(icp0KeyQb64);
 
-        const icp0 = incept({
-            keys: [signKey1qb64],
-            ndigs: [rotKey1Digest]
-        })
+        // raw CESR stream for all messages for KEL - to send to Parser later
+        let msgs = Buffer.alloc(0);
 
+        // Event 0, inception (first event)
+        const icp0Srdr = incept({
+            keys: [icp0KeyQb64],
+            ndigs: [rot1KeyDigest],
+        });
+        const eventDigs = [icp0Srdr.said];
+        let counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        let siger = signKey.sign(b(icp0Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(icp0Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
 
-        expect(parser).toBeInstanceOf(Parser);
+        expect(d(msgs)).toEqual(
+            `{` +
+                `"v":"KERI10JSON00012b_","t":"icp","d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",` +
+                `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"0","kt":"1",` +
+                `"k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],"nt":"1",` +
+                `"n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],"bt":"0","b":[],"c":[],"a":[]}` +
+                `-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E`
+        );
+
+        // Event 1, Rotation transferable (second event)
+        signKey = signers[1];
+        nextKey = signers[2];
+        const rot1KeyQb64 = signKey.verfer.qb64; // use key from prior event (prior next key) as current signing key
+        const rot2KeyQb64b = nextKey.verfer.qb64b;
+        const rot2KeyDigest = new Diger(
+            { code: MtrDex.Blake3_256 },
+            rot2KeyQb64b
+        ).qb64;
+        const rot1Srdr = rotate({
+            pre: icp0Srdr.pre,
+            keys: [rot1KeyQb64],
+            dig: icp0Srdr.said,
+            ndigs: [rot2KeyDigest],
+            sn: 1,
+        });
+        eventDigs.push(rot1Srdr.said);
+        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        siger = signKey.sign(b(rot1Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(rot1Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        expect(d(msgs)).toEqual(
+            `{"v":"KERI10JSON00012b_","t":"icp","d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",` +
+                `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"0","kt":"1",` +
+                `"k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],"nt":"1",` +
+                `"n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],"bt":"0","b":[],"c":[],"a":[]}` +
+                `-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E` +
+                `{"v":"KERI10JSON000160_","t":"rot","d":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",` +
+                `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"1","p":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",` +
+                `"kt":"1","k":["DOwvH3i0ceL1GBqaLxecDIsk6NFDL-Qv6SFq5Gj6JMAB"],` +
+                `"nt":"1","n":["EFOcjb2T4uNP6C20sStcAzOyXDU27_2vWpTzAFbTarAc"],"bt":"0","br":[],"ba":[],"a":[]}` +
+                `-AABAAD29Xiiek51i8FBEIenIDOOj0j3CuKbIeRK9aNNSyMyyH88ho9qb6ietcQjKy4bcERbCHC5t7fkdt7jMW8YT5IN`
+        );
+
+        // Event 2, Rotation Transferable (third event)
+        signKey = signers[2];
+        nextKey = signers[3];
+        const rot2KeyQb64 = signKey.verfer.qb64; // use key from prior event (prior next key) as current signing key
+        const rot3KeyQb64b = nextKey.verfer.qb64b; // next key of 8 signers to use as next rotation key
+        const rot3KeyDigest = new Diger(
+            { code: MtrDex.Blake3_256 },
+            rot3KeyQb64b
+        ).qb64;
+        const rot2Srdr = rotate({
+            pre: icp0Srdr.pre,
+            keys: [rot2KeyQb64],
+            dig: rot1Srdr.said,
+            ndigs: [rot3KeyDigest],
+            sn: 2,
+        });
+        eventDigs.push(rot2Srdr.said);
+        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        siger = signKey.sign(b(rot2Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(rot2Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        // Event 3, Interaction (fourth event)
+        const ixn3Srdr = interact({
+            pre: icp0Srdr.pre,
+            dig: rot2Srdr.said,
+            sn: 3,
+            data: [],
+            kind: Serials.JSON,
+            version: Vrsn_1_0,
+        });
+        eventDigs.push(ixn3Srdr.said);
+        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        siger = signKey.sign(b(ixn3Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(ixn3Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        // Event 4, Interaction (fifth event)
+        const ixn4Srdr = interact({
+            pre: icp0Srdr.pre,
+            dig: ixn3Srdr.said,
+            sn: 4,
+            data: [],
+            kind: Serials.JSON,
+            version: Vrsn_1_0,
+        });
+        eventDigs.push(ixn4Srdr.said);
+        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        siger = signKey.sign(b(ixn4Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(ixn4Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        // Event 5, Rotation (sixth event)
+        signKey = signers[3];
+        nextKey = signers[4];
+        const rot3KeyQb64 = signKey.verfer.qb64;
+        const rot5KeyQb64b = nextKey.verfer.qb64b;
+        const rot5KeyDigest = new Diger(
+            { code: MtrDex.Blake3_256 },
+            rot5KeyQb64b
+        ).qb64;
+        const rot5Srdr = rotate({
+            pre: icp0Srdr.pre,
+            keys: [rot3KeyQb64],
+            dig: ixn4Srdr.said,
+            ndigs: [rot5KeyDigest],
+            sn: 5,
+        });
+        eventDigs.push(rot5Srdr.said);
+        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        siger = signKey.sign(b(rot5Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(rot5Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        // Event 6, Interaction (seventh event)
+        const ixn6Srdr = interact({
+            pre: icp0Srdr.pre,
+            dig: rot5Srdr.said,
+            sn: 6,
+            data: [],
+            kind: Serials.JSON,
+            version: Vrsn_1_0,
+        });
+        eventDigs.push(ixn6Srdr.said);
+        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        siger = signKey.sign(b(ixn6Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(ixn6Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        // Event 7, Rotation to null non-transferable (abandon keypair) - eighth event
+        signKey = signers[4];
+        const rot5KeyQb64 = signKey.verfer.qb64;
+        const rot7Srdr = rotate({
+            pre: icp0Srdr.pre,
+            keys: [rot5KeyQb64],
+            dig: ixn6Srdr.said,
+            sn: 7,
+        });
+        eventDigs.push(rot7Srdr.said);
+        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        siger = signKey.sign(b(rot7Srdr.raw), 0);
+        msgs = Buffer.concat([msgs, b(rot7Srdr.raw)]);
+        msgs = Buffer.concat([msgs, counter.qb64b]);
+        msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        expect(msgs.length).toEqual(3006);
+        // @formatter:off
+        // prettier-ignore
+        const keripyCESRStr =
+          // event 1 icp, sn 0
+           `{"v":"KERI10JSON00012b_","t":"icp","d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"0",`
+          + `"kt":"1","k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],`
+          + `"nt":"1","n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],"bt":"0","b":[],"c":[],"a":[]}`
+          + `-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E`
+          // event 2 rot, sn 1
+          +`{"v":"KERI10JSON000160_","t":"rot","d":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"1","p":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",`
+          + `"kt":"1","k":["DOwvH3i0ceL1GBqaLxecDIsk6NFDL-Qv6SFq5Gj6JMAB"],`
+          + `"nt":"1","n":["EFOcjb2T4uNP6C20sStcAzOyXDU27_2vWpTzAFbTarAc"],"bt":"0","br":[],"ba":[],"a":[]}`
+          + `-AABAAD29Xiiek51i8FBEIenIDOOj0j3CuKbIeRK9aNNSyMyyH88ho9qb6ietcQjKy4bcERbCHC5t7fkdt7jMW8YT5IN`
+          // event 3 rot, sn 2
+          +`{"v":"KERI10JSON000160_","t":"rot","d":"EHdVYE9HBxEBFMzEyo8Cbp1BBzsbbUFyZ4qQ3L5kZVnO",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"2","p":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",`
+          + `"kt":"1","k":["DAGO1PiBVK8Jzj0GqN871WJJAL6DXtZ_7BeSb8LakAbS"],`
+          + `"nt":"1","n":["EEPCpzJEEBdbSkTVJB92tn5aLmWyeBMUdz0iDtyNdgdn"],"bt":"0","br":[],"ba":[],"a":[]}`
+          + `-AABAADEpCJe4OAw-L7_NFx7Cm-SEBva6pHTE7PzcemJ8LDv5sBaak0F3v9DkqSKXAjT8xe0dF6CAAiprpnt9-NompUB`
+          // event 4 ixn, sn 3
+          +`{"v":"KERI10JSON0000cb_","t":"ixn","d":"EK0IxKaIRCIW197CaM24cjlOP9dLuvcRQ4hsUbI-czFc",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"3","p":"EHdVYE9HBxEBFMzEyo8Cbp1BBzsbbUFyZ4qQ3L5kZVnO","a":[]}`
+          + `-AABAABSGEUpho310XVTOJs355Yz6zruY4T6DwAEOln20nvfu-NtG8KhUimxvcL98V2oibSdtD3KZQc5wDmkkDG6duQN`
+          +`{"v":"KERI10JSON0000cb_","t":"ixn","d":"EDia68NPn8go5ZEG-aFRVQx35bTbd2KdkX8wjaDZnfQT",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"4","p":"EK0IxKaIRCIW197CaM24cjlOP9dLuvcRQ4hsUbI-czFc","a":[]}`
+          + `-AABAACmmvkaQSj6GIsi6GY2gM6dF0j6jJldCDlPSllK9F-rB8oBsf6Zw5RNgtQf1ybkAdO_QF6-zjsH8X4DwN1PLAMH`
+          // event 5 rot, sn 5
+          +`{"v":"KERI10JSON000160_","t":"rot","d":"EM0X0dMakhwj_H-WoaAtESja6d952Fi1JDrUtp1tGQTf",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"5","p":"EDia68NPn8go5ZEG-aFRVQx35bTbd2KdkX8wjaDZnfQT",`
+          + `"kt":"1","k":["DMkoIldTmEcAPMTUYvdG40e0MMYXJYVQKVMe8RnZCctX"],`
+          + `"nt":"1","n":["EMYJJC96GwDK0rO6RKgz5R8ehShJbRPk6Y4NYq7URiNp"],"bt":"0","br":[],"ba":[],"a":[]}`
+          + `-AABAACVy62ybeKd4spCvB0w0q3vop9Vgs6loCMyfBYssfUbHM7iR59a9eZBWSdrOGR_684br3j_7QB6FFs0yhgI9-UB`
+          // event 6 ixn, sn 6
+          +`{"v":"KERI10JSON0000cb_","t":"ixn","d":"ECMrnSaWbI9lHX5GtuWu4_cNDNW--8jyn2RTUepjGUBn",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"6","p":"EM0X0dMakhwj_H-WoaAtESja6d952Fi1JDrUtp1tGQTf","a":[]}`
+          + `-AABAACfFj5T8P1caAC_wmn8D7MQYzgFai8WP8BN8HI42cpBmE7wU2gJy4HSzt6CKFJgKmrjWx1qYMupiZoGgQg-9nME`
+          // event 7 rot, sn 7
+          +`{"v":"KERI10JSON000132_","t":"rot","d":"EHTwtT_CHN5WjnbNIwmHzOtXIJ7oN0mntOSYZISYob6A",`
+          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"7","p":"ECMrnSaWbI9lHX5GtuWu4_cNDNW--8jyn2RTUepjGUBn",`
+          + `"kt":"1","k":["DHMGP2ArtkaBPTXyY48smcESmoaUFT5hYBrLNi8ul2tZ"],`
+          + `"nt":"0","n":[],"bt":"0","br":[],"ba":[],"a":[]}`
+          + `-AABAABLPx9jZm8wjHMJaUw176A59cRWLitDnjx1F0C1y2E2T8QNnL2F6YsA1DdkueixoaMN0bCVqxAHL80xfrADfycP`;
+        // @formatter:on
+        // TODO try to interact and rotate after abandonment and verify that an error is thrown
+        expect(d(msgs)).toEqual(keripyCESRStr);
+
+        const cesrMsgs = [];
+        for (const msg of parser.parse(msgs)) {
+            if (msg) {
+                cesrMsgs.push(msg);
+            }
+        }
+        expect(cesrMsgs.length).toBe(8);
     });
 });

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -1,0 +1,30 @@
+// write a test in jest of the Parser class
+import { Parser } from '../../src/keri/core/parsing';
+import signify, { b, d, Diger, incept, MtrDex, Salter, Tier } from "../../src";
+
+describe('Parser', () => {
+    let parser: Parser;
+
+    beforeEach(() => {
+        parser = new Parser();
+    });
+
+    it('should create a new Parser instance', async () => {
+        await signify.ready();
+        const raw = b('ABCDEFGH01234567');
+        const signers = new Salter({ raw }).signers(8, 'psr', MtrDex.Ed25519_Seed, true, 0, Tier.low, true);
+
+        const signKey1qb64 = signers[0].verfer.qb64;
+        const rotKey1qb64b = signers[1].verfer.qb64b;
+        const rotKey1Digest = new Diger({code: MtrDex.Blake3_256}, rotKey1qb64b).qb64
+        expect(signers[0].verfer.qb64).toEqual(signKey1qb64)
+
+        const icp0 = incept({
+            keys: [signKey1qb64],
+            ndigs: [rotKey1Digest]
+        })
+
+
+        expect(parser).toBeInstanceOf(Parser);
+    });
+});

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -67,8 +67,8 @@ describe('Parser', () => {
           +`"d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",`
           +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
           +`"s":"0",`
-          +`"kt":"1","k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],`
-          +`"nt":"1","n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],`
+          +`"kt":"1","k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],` // isith, icount
+          +`"nt":"1","n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],` // nsith, ncount
           +`"bt":"0","b":[],"c":[],"a":[]}`
           +`-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E`;
 
@@ -316,7 +316,7 @@ describe('Parser', () => {
 
         // test that parsing works
         const cesrMsgs: CESRMessage[] = [];
-        for (const msg of parser.parse(msgs)) {
+        for (const msg of parser.msgParsator(msgs)) {
             if (msg) {
                 cesrMsgs.push(msg);
             }

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -1,9 +1,9 @@
 // write a test in jest of the Parser class
-import { Parser } from '../../src/keri/core/parsing';
+import { CESRMessage, Parser } from '../../src/keri/core/parsing';
 import signify, {
     b,
     Counter,
-    CtrDex,
+    CtrDex_1_0,
     d,
     Diger,
     incept,
@@ -56,20 +56,23 @@ describe('Parser', () => {
             ndigs: [rot1KeyDigest],
         });
         const eventDigs = [icp0Srdr.said];
-        let counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        let counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         let siger = signKey.sign(b(icp0Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(icp0Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
 
-        expect(d(msgs)).toEqual(
-            `{` +
-                `"v":"KERI10JSON00012b_","t":"icp","d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",` +
-                `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"0","kt":"1",` +
-                `"k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],"nt":"1",` +
-                `"n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],"bt":"0","b":[],"c":[],"a":[]}` +
-                `-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E`
-        );
+        const cesrMsg0 =
+          `{"v":"KERI10JSON00012b_","t":"icp",`
+          +`"d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"0",`
+          +`"kt":"1","k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],`
+          +`"nt":"1","n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],`
+          +`"bt":"0","b":[],"c":[],"a":[]}`
+          +`-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E`;
+
+        expect(d(msgs)).toEqual(cesrMsg0);
 
         // Event 1, Rotation transferable (second event)
         signKey = signers[1];
@@ -88,24 +91,24 @@ describe('Parser', () => {
             sn: 1,
         });
         eventDigs.push(rot1Srdr.said);
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         siger = signKey.sign(b(rot1Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(rot1Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
 
-        expect(d(msgs)).toEqual(
-            `{"v":"KERI10JSON00012b_","t":"icp","d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",` +
-                `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"0","kt":"1",` +
-                `"k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],"nt":"1",` +
-                `"n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],"bt":"0","b":[],"c":[],"a":[]}` +
-                `-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E` +
-                `{"v":"KERI10JSON000160_","t":"rot","d":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",` +
-                `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"1","p":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",` +
-                `"kt":"1","k":["DOwvH3i0ceL1GBqaLxecDIsk6NFDL-Qv6SFq5Gj6JMAB"],` +
-                `"nt":"1","n":["EFOcjb2T4uNP6C20sStcAzOyXDU27_2vWpTzAFbTarAc"],"bt":"0","br":[],"ba":[],"a":[]}` +
-                `-AABAAD29Xiiek51i8FBEIenIDOOj0j3CuKbIeRK9aNNSyMyyH88ho9qb6ietcQjKy4bcERbCHC5t7fkdt7jMW8YT5IN`
-        );
+        const cesrMsg1 =
+          `{"v":"KERI10JSON000160_","t":"rot",`
+          +`"d":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"1",`
+          +`"p":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",`
+          +`"kt":"1","k":["DOwvH3i0ceL1GBqaLxecDIsk6NFDL-Qv6SFq5Gj6JMAB"],`
+          +`"nt":"1","n":["EFOcjb2T4uNP6C20sStcAzOyXDU27_2vWpTzAFbTarAc"],`
+          +`"bt":"0","br":[],"ba":[],"a":[]}`
+          +`-AABAAD29Xiiek51i8FBEIenIDOOj0j3CuKbIeRK9aNNSyMyyH88ho9qb6ietcQjKy4bcERbCHC5t7fkdt7jMW8YT5IN`;
+
+        expect(d(msgs)).toEqual(cesrMsg0 + cesrMsg1);
 
         // Event 2, Rotation Transferable (third event)
         signKey = signers[2];
@@ -124,11 +127,24 @@ describe('Parser', () => {
             sn: 2,
         });
         eventDigs.push(rot2Srdr.said);
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         siger = signKey.sign(b(rot2Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(rot2Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        const cesrMsg2 =
+          `{"v":"KERI10JSON000160_","t":"rot",`
+          +`"d":"EHdVYE9HBxEBFMzEyo8Cbp1BBzsbbUFyZ4qQ3L5kZVnO",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"2",`
+          +`"p":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",`
+          +`"kt":"1","k":["DAGO1PiBVK8Jzj0GqN871WJJAL6DXtZ_7BeSb8LakAbS"],`
+          +`"nt":"1","n":["EEPCpzJEEBdbSkTVJB92tn5aLmWyeBMUdz0iDtyNdgdn"],`
+          +`"bt":"0","br":[],"ba":[],"a":[]}`
+          +`-AABAADEpCJe4OAw-L7_NFx7Cm-SEBva6pHTE7PzcemJ8LDv5sBaak0F3v9DkqSKXAjT8xe0dF6CAAiprpnt9-NompUB`
+
+        expect(d(msgs)).toEqual(cesrMsg0 + cesrMsg1 + cesrMsg2);
 
         // Event 3, Interaction (fourth event)
         const ixn3Srdr = interact({
@@ -140,11 +156,21 @@ describe('Parser', () => {
             version: Vrsn_1_0,
         });
         eventDigs.push(ixn3Srdr.said);
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         siger = signKey.sign(b(ixn3Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(ixn3Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        const cesrMsg3 =
+          `{"v":"KERI10JSON0000cb_","t":"ixn",`
+          +`"d":"EK0IxKaIRCIW197CaM24cjlOP9dLuvcRQ4hsUbI-czFc",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"3",`
+          +`"p":"EHdVYE9HBxEBFMzEyo8Cbp1BBzsbbUFyZ4qQ3L5kZVnO","a":[]}`
+          +`-AABAABSGEUpho310XVTOJs355Yz6zruY4T6DwAEOln20nvfu-NtG8KhUimxvcL98V2oibSdtD3KZQc5wDmkkDG6duQN`
+
+        expect(d(msgs)).toEqual(cesrMsg0 + cesrMsg1 + cesrMsg2 + cesrMsg3);
 
         // Event 4, Interaction (fifth event)
         const ixn4Srdr = interact({
@@ -156,11 +182,21 @@ describe('Parser', () => {
             version: Vrsn_1_0,
         });
         eventDigs.push(ixn4Srdr.said);
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         siger = signKey.sign(b(ixn4Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(ixn4Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        const cesrMsg4 =
+          `{"v":"KERI10JSON0000cb_","t":"ixn",`
+          +`"d":"EDia68NPn8go5ZEG-aFRVQx35bTbd2KdkX8wjaDZnfQT",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"4",`
+          +`"p":"EK0IxKaIRCIW197CaM24cjlOP9dLuvcRQ4hsUbI-czFc","a":[]}`
+          +`-AABAACmmvkaQSj6GIsi6GY2gM6dF0j6jJldCDlPSllK9F-rB8oBsf6Zw5RNgtQf1ybkAdO_QF6-zjsH8X4DwN1PLAMH`;
+
+        expect(d(msgs)).toEqual(cesrMsg0 + cesrMsg1 + cesrMsg2 + cesrMsg3 + cesrMsg4);
 
         // Event 5, Rotation (sixth event)
         signKey = signers[3];
@@ -179,11 +215,26 @@ describe('Parser', () => {
             sn: 5,
         });
         eventDigs.push(rot5Srdr.said);
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         siger = signKey.sign(b(rot5Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(rot5Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        const cesrMsg5 =
+          `{"v":"KERI10JSON000160_","t":"rot",`
+          +`"d":"EM0X0dMakhwj_H-WoaAtESja6d952Fi1JDrUtp1tGQTf",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"5",`
+          +`"p":"EDia68NPn8go5ZEG-aFRVQx35bTbd2KdkX8wjaDZnfQT",`
+          +`"kt":"1","k":["DMkoIldTmEcAPMTUYvdG40e0MMYXJYVQKVMe8RnZCctX"],`
+          +`"nt":"1","n":["EMYJJC96GwDK0rO6RKgz5R8ehShJbRPk6Y4NYq7URiNp"],`
+          +`"bt":"0","br":[],"ba":[],"a":[]}`
+          +`-AABAACVy62ybeKd4spCvB0w0q3vop9Vgs6loCMyfBYssfUbHM7iR59a9eZBWSdrOGR_684br3j_7QB6FFs0yhgI9-UB`
+
+        expect(d(msgs)).toEqual(
+          cesrMsg0 + cesrMsg1 + cesrMsg2 +
+          cesrMsg3 + cesrMsg4 + cesrMsg5);
 
         // Event 6, Interaction (seventh event)
         const ixn6Srdr = interact({
@@ -195,11 +246,22 @@ describe('Parser', () => {
             version: Vrsn_1_0,
         });
         eventDigs.push(ixn6Srdr.said);
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         siger = signKey.sign(b(ixn6Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(ixn6Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        const cesrMsg6 =
+          `{"v":"KERI10JSON0000cb_","t":"ixn",`
+          +`"d":"ECMrnSaWbI9lHX5GtuWu4_cNDNW--8jyn2RTUepjGUBn",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"6",`
+          +`"p":"EM0X0dMakhwj_H-WoaAtESja6d952Fi1JDrUtp1tGQTf","a":[]}`
+          +`-AABAACfFj5T8P1caAC_wmn8D7MQYzgFai8WP8BN8HI42cpBmE7wU2gJy4HSzt6CKFJgKmrjWx1qYMupiZoGgQg-9nME`
+
+        expect(d(msgs)).toEqual(cesrMsg0 + cesrMsg1 + cesrMsg2 +
+          cesrMsg3 + cesrMsg4 + cesrMsg5 + cesrMsg6);
 
         // Event 7, Rotation to null non-transferable (abandon keypair) - eighth event
         signKey = signers[4];
@@ -211,67 +273,80 @@ describe('Parser', () => {
             sn: 7,
         });
         eventDigs.push(rot7Srdr.said);
-        counter = new Counter({ code: CtrDex.ControllerIdxSigs });
+        counter = new Counter({ code: CtrDex_1_0.ControllerIdxSigs });
         siger = signKey.sign(b(rot7Srdr.raw), 0);
         msgs = Buffer.concat([msgs, b(rot7Srdr.raw)]);
         msgs = Buffer.concat([msgs, counter.qb64b]);
         msgs = Buffer.concat([msgs, siger.qb64b]);
+
+        const cesrMsg7 =
+          `{"v":"KERI10JSON000132_","t":"rot",`
+          +`"d":"EHTwtT_CHN5WjnbNIwmHzOtXIJ7oN0mntOSYZISYob6A",`
+          +`"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx",`
+          +`"s":"7",`
+          +`"p":"ECMrnSaWbI9lHX5GtuWu4_cNDNW--8jyn2RTUepjGUBn",`
+          +`"kt":"1","k":["DHMGP2ArtkaBPTXyY48smcESmoaUFT5hYBrLNi8ul2tZ"],`
+          +`"nt":"0","n":[],` // rotates to null (empty) keypair list, abandoning the identifier
+          +`"bt":"0","br":[],"ba":[],"a":[]}`
+          +`-AABAABLPx9jZm8wjHMJaUw176A59cRWLitDnjx1F0C1y2E2T8QNnL2F6YsA1DdkueixoaMN0bCVqxAHL80xfrADfycP`
 
         expect(msgs.length).toEqual(3006);
         // @formatter:off
         // prettier-ignore
         const keripyCESRStr =
           // event 1 icp, sn 0
-           `{"v":"KERI10JSON00012b_","t":"icp","d":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"0",`
-          + `"kt":"1","k":["DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx"],`
-          + `"nt":"1","n":["EFXIx7URwmw7AVQTBcMxPXfOOJ2YYA1SJAam69DXV8D2"],"bt":"0","b":[],"c":[],"a":[]}`
-          + `-AABAAApXLez5eVIs6YyRXOMDMBy4cTm2GvsilrZlcMmtBbO5twLst_jjFoEyfKTWKntEtv9JPBv1DLkqg-ImDmGPM8E`
+          cesrMsg0
           // event 2 rot, sn 1
-          +`{"v":"KERI10JSON000160_","t":"rot","d":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"1","p":"EIcca2-uqsicYK7-q5gxlZXuzOkqrNSL3JIaLflSOOgF",`
-          + `"kt":"1","k":["DOwvH3i0ceL1GBqaLxecDIsk6NFDL-Qv6SFq5Gj6JMAB"],`
-          + `"nt":"1","n":["EFOcjb2T4uNP6C20sStcAzOyXDU27_2vWpTzAFbTarAc"],"bt":"0","br":[],"ba":[],"a":[]}`
-          + `-AABAAD29Xiiek51i8FBEIenIDOOj0j3CuKbIeRK9aNNSyMyyH88ho9qb6ietcQjKy4bcERbCHC5t7fkdt7jMW8YT5IN`
+          + cesrMsg1
           // event 3 rot, sn 2
-          +`{"v":"KERI10JSON000160_","t":"rot","d":"EHdVYE9HBxEBFMzEyo8Cbp1BBzsbbUFyZ4qQ3L5kZVnO",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"2","p":"EJDbQDHpeEoKjZLbs08GKBxIXhe9T-Xi7mbejQmJdnZG",`
-          + `"kt":"1","k":["DAGO1PiBVK8Jzj0GqN871WJJAL6DXtZ_7BeSb8LakAbS"],`
-          + `"nt":"1","n":["EEPCpzJEEBdbSkTVJB92tn5aLmWyeBMUdz0iDtyNdgdn"],"bt":"0","br":[],"ba":[],"a":[]}`
-          + `-AABAADEpCJe4OAw-L7_NFx7Cm-SEBva6pHTE7PzcemJ8LDv5sBaak0F3v9DkqSKXAjT8xe0dF6CAAiprpnt9-NompUB`
+          + cesrMsg2
           // event 4 ixn, sn 3
-          +`{"v":"KERI10JSON0000cb_","t":"ixn","d":"EK0IxKaIRCIW197CaM24cjlOP9dLuvcRQ4hsUbI-czFc",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"3","p":"EHdVYE9HBxEBFMzEyo8Cbp1BBzsbbUFyZ4qQ3L5kZVnO","a":[]}`
-          + `-AABAABSGEUpho310XVTOJs355Yz6zruY4T6DwAEOln20nvfu-NtG8KhUimxvcL98V2oibSdtD3KZQc5wDmkkDG6duQN`
-          +`{"v":"KERI10JSON0000cb_","t":"ixn","d":"EDia68NPn8go5ZEG-aFRVQx35bTbd2KdkX8wjaDZnfQT",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"4","p":"EK0IxKaIRCIW197CaM24cjlOP9dLuvcRQ4hsUbI-czFc","a":[]}`
-          + `-AABAACmmvkaQSj6GIsi6GY2gM6dF0j6jJldCDlPSllK9F-rB8oBsf6Zw5RNgtQf1ybkAdO_QF6-zjsH8X4DwN1PLAMH`
-          // event 5 rot, sn 5
-          +`{"v":"KERI10JSON000160_","t":"rot","d":"EM0X0dMakhwj_H-WoaAtESja6d952Fi1JDrUtp1tGQTf",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"5","p":"EDia68NPn8go5ZEG-aFRVQx35bTbd2KdkX8wjaDZnfQT",`
-          + `"kt":"1","k":["DMkoIldTmEcAPMTUYvdG40e0MMYXJYVQKVMe8RnZCctX"],`
-          + `"nt":"1","n":["EMYJJC96GwDK0rO6RKgz5R8ehShJbRPk6Y4NYq7URiNp"],"bt":"0","br":[],"ba":[],"a":[]}`
-          + `-AABAACVy62ybeKd4spCvB0w0q3vop9Vgs6loCMyfBYssfUbHM7iR59a9eZBWSdrOGR_684br3j_7QB6FFs0yhgI9-UB`
-          // event 6 ixn, sn 6
-          +`{"v":"KERI10JSON0000cb_","t":"ixn","d":"ECMrnSaWbI9lHX5GtuWu4_cNDNW--8jyn2RTUepjGUBn",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"6","p":"EM0X0dMakhwj_H-WoaAtESja6d952Fi1JDrUtp1tGQTf","a":[]}`
-          + `-AABAACfFj5T8P1caAC_wmn8D7MQYzgFai8WP8BN8HI42cpBmE7wU2gJy4HSzt6CKFJgKmrjWx1qYMupiZoGgQg-9nME`
-          // event 7 rot, sn 7
-          +`{"v":"KERI10JSON000132_","t":"rot","d":"EHTwtT_CHN5WjnbNIwmHzOtXIJ7oN0mntOSYZISYob6A",`
-          + `"i":"DNG2arBDtHK_JyHRAq-emRdC6UM-yIpCAeJIWDiXp4Hx","s":"7","p":"ECMrnSaWbI9lHX5GtuWu4_cNDNW--8jyn2RTUepjGUBn",`
-          + `"kt":"1","k":["DHMGP2ArtkaBPTXyY48smcESmoaUFT5hYBrLNi8ul2tZ"],`
-          + `"nt":"0","n":[],"bt":"0","br":[],"ba":[],"a":[]}`
-          + `-AABAABLPx9jZm8wjHMJaUw176A59cRWLitDnjx1F0C1y2E2T8QNnL2F6YsA1DdkueixoaMN0bCVqxAHL80xfrADfycP`;
+          + cesrMsg3
+          // event 5 ixn, sn 4
+          + cesrMsg4
+          // event 6 rot, sn 5
+          + cesrMsg5
+          // event 7 ixn, sn 6
+          + cesrMsg6
+          // event 8 rot, sn 7
+          + cesrMsg7;
         // @formatter:on
         // TODO try to interact and rotate after abandonment and verify that an error is thrown
-        expect(d(msgs)).toEqual(keripyCESRStr);
+        expect(d(msgs), 'full stream did not verify').toEqual(keripyCESRStr);
 
-        const cesrMsgs = [];
+        // test that parsing works
+        const cesrMsgs: CESRMessage[] = [];
         for (const msg of parser.parse(msgs)) {
             if (msg) {
                 cesrMsgs.push(msg);
             }
         }
         expect(cesrMsgs.length).toBe(8);
+
+        // test that packing works
+        const packed = parser.pack(cesrMsgs[0]);
+        expect(d(packed), 'First packed method is not equal to first message and attachments')
+          .toEqual(cesrMsg0);
+
+        let allPacked: Buffer = Buffer.from([]);
+        for (const msg of cesrMsgs) {
+            const packed = parser.pack(msg);
+            allPacked = Buffer.concat([allPacked, packed]);
+        }
+        expect(d(allPacked), 'All packed messages are not equal to the full stream')
+          .toEqual(keripyCESRStr);
+
+        // const primitives: (Indexer | Matter | Counter)[] = [];
+        // for (const msg of cesrMsgs) {
+        //     const body = Hydrator.create(msg.body.bytes);
+        //     for (const atc of msg.atc.attachments) {
+        //         const attachment = Hydrator.create(atc.bytes);
+        //
+        //     }
+        // }
+
+        // put objects into KERI databases (KEL, TEL, EXN, Router, Vry)
+        // take objects and put them in key event log (KEL)
+        // take credential (ACDC) objects and put them in transaction event log (TEL)
     });
 });


### PR DESCRIPTION
This contains a draft CESR parser. The goal of this parser was to only slice up the byte stream into a set of CESR Messages as described in the last sentence of [section 1 - Introduction][CESR_SEC_1] of the CESR Spec:

> Properly, in CESR parlance, a full Message consists of a Message Body plus Attachments.

This **DRAFT** PR establishes the following classes for a CESR parser, my own interpretation based on KERIpy and my understanding of CESR. It is up for debate. [Union types][CESR_UNION] were used to enable simple nesting of attachment groups with a decently small set of types.

- [CESRMessage][CESR_MSG]: Contains a Body and Attachments. A CESR stream is just a sequence of CESR Messages.
- [CESRBody][CESR_BODY]: Contains the JSON/CBOR/MGPK object that is a KEL event, TEL event, EXN message, Reply, Query, or other message.
- [CESRAttachments][CESR_ATC]: Contains all attachment groups. Groups are composed of either primitives, tuples, or nested groups.
  - [CESRAtcGroup][CESR_GRP]: A single group of primitives that may have primitives, tuples, or nested groups.
    - [CESRPrim][CESR_PRIM]: A single CESR attachment primitive.
    - [CESRTuple][CESR_TUPLE]: A tuple of CESR primitives, tuples, or groups. This simplified mimicking KERIpy's tuple return types from the parsing rules in [`parsing.py`][PARSING_PY]
    - [PrimType][CESR_PT]: A marker of what kind of primitive to instantiate when turning the CESRPrim objects into actual cryptographic primitives.

## Current State

INCOMPLETE - WORK IN PROGRESS - 15% - 20% done, 2/14 parse rules tested

The single test included only tests controller indexed signatures, or `ColdDex.ControllerIdxSigs`, which is only testing one of the attachment parse rules (`-A`) and one of the body parse rules (`SerderKERI`).

## Next Steps

- [ ] Write tests for the other 12 of 14 parse rules.
- [ ] Convert CESRMessage instances into cryptographic primitives.
- [ ] Write unit tests verifying correct instantiation of cryptographic primitives from CESRMessage instances.
- [ ] Write unit tests showing KEL construction works from CESR streams.
- [ ] Write unit tests showing management TEL and ACDC TEL construction works from CESR streams.
- [ ] Write unit tests showing that EXN, rpy, qry, and other messages are properly constructed from CESR streams.

[CESR_ATC]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L205
[CESR_BODY]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L89
[CESR_GRP]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L165
[CESR_MSG]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L221
[CESR_PRIM]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L132
[CESR_PT]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L111
[CESR_SEC_1]: https://trustoverip.github.io/tswg-cesr-specification/#introduction
[CESR_TUPLE]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L152
[CESR_UNION]: https://github.com/kentbull/signify-ts/blob/parser/src/keri/core/parsing.ts#L150
[PARSING_PY]: https://github.com/WebOfTrust/keripy/blob/main/src/keri/core/parsing.py#L772